### PR TITLE
しゃうさぎ氏を1mから10000mまで投げられるよう修正

### DIFF
--- a/TwitDuke-Server/src/main/java/net/nokok/twitduke/server/handlers/ThrowShoutrockHandler.java
+++ b/TwitDuke-Server/src/main/java/net/nokok/twitduke/server/handlers/ThrowShoutrockHandler.java
@@ -41,7 +41,7 @@ public class ThrowShoutrockHandler implements Retrievable<Handler> {
 
         @Override
         public void doHandle(HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
-            asyncTwitter.updateStatus("しゃうさぎ氏を" + new SecureRandom().nextInt(10000) + "m飛ばしました #TwitDuke");
+            asyncTwitter.updateStatus("しゃうさぎ氏を" + (new SecureRandom().nextInt(10000) + 1) + "m飛ばしました #TwitDuke");
             sendOK();
         }
 


### PR DESCRIPTION
SecureRandom#nextIntの実装により、9999mまでしか投げられないため+1mを単純に加算。
