### PR TITLE
[FIX]  サーバー起動後の処理が行われない問題 #47 の修正

### DIFF
--- a/TwitDuke/src/main/java/net/nokok/twitduke/Main.java
+++ b/TwitDuke/src/main/java/net/nokok/twitduke/Main.java
@@ -152,7 +152,7 @@ public class Main extends Application {
     private static void startServer(AccessToken accessToken) {
         try {
             Runnable server = new WebServerStarter(accessToken);
-            server.run();
+            new Thread(server).start();
         } catch (RuntimeException e) {
             throw new RuntimeException("サーバーが既に起動しています。ポート:8192が使用できません。", e);
         }


### PR DESCRIPTION
https://github.com/nokok/TwitDuke/blob/master/TwitDuke/src/main/java/net/nokok/twitduke/Main.java#L155のrunメソッドをThread.startに変更
