### PR TITLE
tweetTextareaへキーボード入力を行えないバグを修正

### DIFF
--- a/TwitDuke-Components/src/main/java/net/nokok/twitduke/components/javafx/MainViewController.java
+++ b/TwitDuke-Components/src/main/java/net/nokok/twitduke/components/javafx/MainViewController.java
@@ -35,6 +35,7 @@ import javafx.scene.control.TabPane;
 import javafx.scene.control.TextArea;
 import javafx.scene.control.ToolBar;
 import javafx.scene.image.ImageView;
+import javafx.scene.input.KeyEvent;
 
 public class MainViewController {
 
@@ -128,12 +129,12 @@ public class MainViewController {
     }
 
     @FXML
-    void tweetTextAreaKeyPressed(ActionEvent event) {
+    void tweetTextAreaKeyPressed(KeyEvent event) {
 
     }
 
     @FXML
-    void tweetTextAreaKeyTyped(ActionEvent event) {
+    void tweetTextAreaKeyTyped(KeyEvent event) {
 
     }
 


### PR DESCRIPTION
 JavaFXへ置き換え #37 について。
tweetTextAreaKeyPressedとtweetTextAreaKeyTypedの引数の型がActionEventだったため例外が発生していました。
これらの引数の型をKeyEventに変更しました。
