### PR TITLE
キーボードショートカット実装に向けて4

### DIFF
--- a/TwitDuke-Components/src/main/java/net/nokok/twitduke/components/actions/ActionUtil.java
+++ b/TwitDuke-Components/src/main/java/net/nokok/twitduke/components/actions/ActionUtil.java
@@ -1,0 +1,87 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package net.nokok.twitduke.components.actions;
+
+/**
+ *
+ * @author wtnbsts
+ */
+public class ActionUtil {
+
+    /**
+     * 文字列と、その文字列中で選択されている場所を渡すと、その選択されている場所の行末の番号を計算する
+     *
+     * @param txt           文字列
+     * @param caretPosition 文字列中で選択されている場所
+     *
+     * @return 行末の番号
+     */
+    public static int getEndOfLine(final String txt, final int caretPosition) {
+        final int lineSepPosition = txt.indexOf(System.lineSeparator(), caretPosition);
+        return lineSepPosition < 0 ? txt.length() : lineSepPosition;
+    }
+
+    /**
+     * 文字列と、その文字列中で選択されている場所を渡すと、その選択されている場所の行頭の番号を計算する
+     *
+     * @param txt           文字列
+     * @param caretPosition 文字列中で選択されている場所
+     *
+     * @return 行頭の番号
+     */
+    public static int getBeginningOfLine(final String txt, final int caretPosition) {
+        final String subtext = txt.substring(0, caretPosition);
+        final int lineSepPosition = subtext.lastIndexOf(System.lineSeparator(), caretPosition);
+        return lineSepPosition < 0 ? 0 : lineSepPosition + System.lineSeparator().length();
+    }
+
+    /**
+     * 文字列と、その文字列中で選択されている場所を渡すと、その選択されている場所の上にある文字の番号を計算する
+     *
+     * @param txt           文字列
+     * @param caretPosition 文字列中で選択されている場所
+     *
+     * @return 上にある文字の番号
+     */
+    public static int getUpSide(final String txt, final int caretPosition) {
+        final int lineStartPosit = getBeginningOfLine(txt, caretPosition);
+        if ( lineStartPosit == 0 ) {
+            // 行の先頭が0番目の文字なら、上に行は存在しない
+            return -1;
+        }
+        final int upSideSepIndex = getEndOfLine(txt, lineStartPosit - 1);//一行上の末尾
+        final int upSideStartIndex = getBeginningOfLine(txt, upSideSepIndex);// 一行上の先頭
+        final int currentColm = caretPosition - lineStartPosit;
+        if ( currentColm > (upSideSepIndex - upSideStartIndex) ) {
+            return upSideSepIndex;
+        } else {
+            return upSideStartIndex + currentColm;
+        }
+    }
+
+    /**
+     * 文字列と、その文字列中で選択されている場所を渡すと、その選択されている場所の下にある文字の番号を計算する
+     *
+     * @param txt           文字列
+     * @param caretPosition 文字列中で選択されている場所
+     *
+     * @return 下にある文字の番号
+     */
+    public static int getDownSide(final String txt, final int caretPosition) {
+        final int lineEndPosit = getEndOfLine(txt, caretPosition);
+        if ( lineEndPosit == txt.length() ) {
+            return -1;
+        }
+        final int downSideSepIndex = getEndOfLine(txt, lineEndPosit + 1);
+        final int downSideStartIndex = getBeginningOfLine(txt, downSideSepIndex);
+        final int currentColm = caretPosition - getBeginningOfLine(txt, caretPosition);
+        if ( currentColm > (downSideSepIndex - downSideStartIndex) ) {
+            return downSideSepIndex;
+        } else {
+            return downSideStartIndex + currentColm;
+        }
+    }
+}

--- a/TwitDuke-Components/src/main/java/net/nokok/twitduke/components/actions/CheckKeyEvent.java
+++ b/TwitDuke-Components/src/main/java/net/nokok/twitduke/components/actions/CheckKeyEvent.java
@@ -1,0 +1,115 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package net.nokok.twitduke.components.actions;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javafx.event.EventHandler;
+import javafx.geometry.Pos;
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.control.TextArea;
+import javafx.scene.input.Clipboard;
+import javafx.scene.input.DataFormat;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.StackPane;
+import javafx.scene.layout.VBox;
+import javafx.stage.Stage;
+
+/**
+ *
+ * @author wtnbsts
+ */
+public class CheckKeyEvent implements EventHandler<KeyEvent> {
+
+    private final static String WITH = "+";
+    private long lastCommandTime = System.currentTimeMillis();
+
+    @SuppressWarnings("unused")
+    @Override
+    public void handle(KeyEvent event) {
+        if ( !(event.getSource() instanceof TextArea) ) {
+            return;
+        }
+        if ( System.currentTimeMillis() - lastCommandTime < 200 ) {
+            return;
+        }
+        final Stage dialog = new Stage();
+        final StackPane pane = new StackPane();
+        dialog.setScene(new Scene(pane));
+        final VBox vbox = new VBox();
+        pane.getChildren().add(vbox);
+
+        vbox.setMinSize(200, 100);
+        vbox.setMaxSize(200, 100);
+        vbox.setAlignment(Pos.CENTER);
+        vbox.getChildren().add(new Label());
+        vbox.getChildren().add(new Label());
+
+        final TextArea textarea = new TextArea("input any key...");
+        vbox.getChildren().add(1, textarea);
+        textarea.setEditable(false);
+        textarea.selectForward();
+        textarea.addEventHandler(KeyEvent.KEY_PRESSED, keyEvent -> {
+            List<KeyCode> keys = new ArrayList<>();
+            if ( keyEvent.isAltDown() ) {
+                keys.add(KeyCode.ALT);
+            }
+            if ( keyEvent.isControlDown() ) {
+                keys.add(KeyCode.CONTROL);
+            }
+            if ( keyEvent.isMetaDown() ) {
+                keys.add(KeyCode.META);
+            }
+            if ( keyEvent.isShiftDown() ) {
+                keys.add(KeyCode.SHIFT);
+            }
+            if ( keyEvent.isShortcutDown() ) {
+                keys.add(KeyCode.SHORTCUT);
+            }
+            if ( !keys.contains(keyEvent.getCode()) ) {
+                keys.add(keyEvent.getCode());
+            }
+            StringBuilder sb = new StringBuilder();
+            keys.forEach(code -> {
+                if ( sb.length() > 0 ) {
+                    sb.append(WITH);
+                }
+                sb.append(code.getName());
+            });
+            textarea.setText(sb.toString());
+        });
+
+        final Button copyButton = new Button();
+        copyButton.setText("Copy");
+        copyButton.setOnAction(boxEvent -> {
+            Map<DataFormat, Object> data = new HashMap<>();
+            data.put(DataFormat.PLAIN_TEXT, textarea.getText());
+            Clipboard.getSystemClipboard().setContent(data);
+        });
+        final Button closeButton = new Button();
+        closeButton.setText("Close");
+        closeButton.setOnAction(boxEvent -> {
+            dialog.close();
+        });
+
+        final HBox buttonPane = new HBox();
+        buttonPane.setAlignment(Pos.CENTER);
+        buttonPane.getChildren().add(copyButton);
+        buttonPane.getChildren().add(new Label("     "));
+        buttonPane.getChildren().add(closeButton);
+
+        vbox.getChildren().add(buttonPane);
+        vbox.getChildren().add(new Label(""));
+        dialog.showAndWait();
+        lastCommandTime = System.currentTimeMillis();
+    }
+}

--- a/TwitDuke-Components/src/main/java/net/nokok/twitduke/components/actions/CutUpToLineEnd.java
+++ b/TwitDuke-Components/src/main/java/net/nokok/twitduke/components/actions/CutUpToLineEnd.java
@@ -1,0 +1,63 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package net.nokok.twitduke.components.actions;
+
+import java.util.HashMap;
+import java.util.Map;
+import javafx.event.EventHandler;
+import javafx.scene.control.TextArea;
+import javafx.scene.input.Clipboard;
+import javafx.scene.input.DataFormat;
+import javafx.scene.input.KeyEvent;
+
+/**
+ *
+ * @author wtnbsts
+ */
+public class CutUpToLineEnd implements EventHandler<KeyEvent> {
+
+    private String lastText;
+    private int lastSelectionStart = -1;
+
+    @Override
+    public void handle(KeyEvent event) {
+        if ( !(event.getSource() instanceof TextArea) ) {
+            return;
+        }
+        final TextArea src = (TextArea) event.getSource();
+        final String txt = src.getText();
+        if ( txt.isEmpty() ) {
+            return;
+        }
+        final int cursorPosition = src.getSelection().getStart();
+        int lineEndPosition = ActionUtil.getEndOfLine(txt, cursorPosition);
+        if ( lineEndPosition < 0 ) {
+            lineEndPosition = txt.length();
+        }
+        String selected = txt.substring(cursorPosition, lineEndPosition);
+        if ( selected.length() == 0 ) {
+            selected = System.lineSeparator();
+            lineEndPosition = cursorPosition + selected.length();
+        }
+        final Clipboard clipboard = Clipboard.getSystemClipboard();
+        if ( txt.equals(lastText)
+             && lastSelectionStart == src.getSelection().getStart()
+             && lastSelectionStart == src.getSelection().getEnd() ) {
+            selected = clipboard.getString() + selected;
+        }
+        final Map<DataFormat, Object> data = new HashMap<>();
+        data.put(DataFormat.PLAIN_TEXT, selected);
+        clipboard.setContent(data);
+
+        final StringBuilder sb = new StringBuilder(txt);
+        sb.delete(cursorPosition, lineEndPosition);
+        src.setText(sb.toString());
+        src.selectRange(cursorPosition, cursorPosition);
+
+        lastSelectionStart = cursorPosition;
+        lastText = src.getText();
+    }
+}

--- a/TwitDuke-Components/src/main/java/net/nokok/twitduke/components/actions/DeleteNextCharacter.java
+++ b/TwitDuke-Components/src/main/java/net/nokok/twitduke/components/actions/DeleteNextCharacter.java
@@ -1,0 +1,24 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package net.nokok.twitduke.components.actions;
+
+import javafx.event.EventHandler;
+import javafx.scene.control.TextArea;
+import javafx.scene.input.KeyEvent;
+
+/**
+ *
+ * @author wtnbsts
+ */
+public class DeleteNextCharacter implements EventHandler<KeyEvent> {
+
+    @Override
+    public void handle(KeyEvent event) {
+        if ( event.getSource() instanceof TextArea ) {
+            ((TextArea) event.getSource()).deleteNextChar();
+        }
+    }
+}

--- a/TwitDuke-Components/src/main/java/net/nokok/twitduke/components/actions/DeletePreviousCharacter.java
+++ b/TwitDuke-Components/src/main/java/net/nokok/twitduke/components/actions/DeletePreviousCharacter.java
@@ -1,0 +1,24 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package net.nokok.twitduke.components.actions;
+
+import javafx.event.EventHandler;
+import javafx.scene.control.TextArea;
+import javafx.scene.input.KeyEvent;
+
+/**
+ *
+ * @author wtnbsts
+ */
+public class DeletePreviousCharacter implements EventHandler<KeyEvent> {
+
+    @Override
+    public void handle(KeyEvent event) {
+        if ( event.getSource() instanceof TextArea ) {
+            ((TextArea) event.getSource()).deletePreviousChar();
+        }
+    }
+}

--- a/TwitDuke-Components/src/main/java/net/nokok/twitduke/components/actions/Hey.java
+++ b/TwitDuke-Components/src/main/java/net/nokok/twitduke/components/actions/Hey.java
@@ -1,0 +1,55 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package net.nokok.twitduke.components.actions;
+
+import javafx.event.EventHandler;
+import javafx.geometry.Pos;
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.control.TextArea;
+import javafx.scene.input.KeyEvent;
+import javafx.scene.layout.StackPane;
+import javafx.scene.layout.VBox;
+import javafx.stage.Stage;
+
+/**
+ *
+ * @author wtnbsts
+ */
+public class Hey implements EventHandler<KeyEvent> {
+
+    private long lastCommandTime = System.currentTimeMillis();
+
+    @Override
+    public void handle(KeyEvent event) {
+        if ( !(event.getSource() instanceof TextArea) ) {
+            return;
+        }
+        if ( System.currentTimeMillis() - lastCommandTime < 200 ) {
+            return;
+        }
+        final Stage dialog = new Stage();
+        final StackPane pane = new StackPane();
+        dialog.setScene(new Scene(pane));
+        final VBox vbox = new VBox();
+        pane.getChildren().add(vbox);
+
+        vbox.setAlignment(Pos.CENTER);
+        vbox.getChildren().add(new Label());
+        vbox.getChildren().add(new Label("   hey! ﾂﾗﾀﾝ...   "));
+        vbox.getChildren().add(new Label());
+        final Button bottom = new Button();
+        bottom.setText("OK");
+        bottom.setOnAction(boxEvent -> {
+            dialog.close();
+        });
+        vbox.getChildren().add(bottom);
+        vbox.getChildren().add(new Label(""));
+        dialog.showAndWait();
+        lastCommandTime = System.currentTimeMillis();
+    }
+}

--- a/TwitDuke-Components/src/main/java/net/nokok/twitduke/components/actions/MoveBackward.java
+++ b/TwitDuke-Components/src/main/java/net/nokok/twitduke/components/actions/MoveBackward.java
@@ -1,0 +1,24 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package net.nokok.twitduke.components.actions;
+
+import javafx.event.EventHandler;
+import javafx.scene.control.TextArea;
+import javafx.scene.input.KeyEvent;
+
+/**
+ *
+ * @author wtnbsts
+ */
+public class MoveBackward implements EventHandler<KeyEvent> {
+
+    @Override
+    public void handle(KeyEvent event) {
+        if ( event.getSource() instanceof TextArea ) {
+            ((TextArea) event.getSource()).backward();
+        }
+    }
+}

--- a/TwitDuke-Components/src/main/java/net/nokok/twitduke/components/actions/MoveDown.java
+++ b/TwitDuke-Components/src/main/java/net/nokok/twitduke/components/actions/MoveDown.java
@@ -1,0 +1,30 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package net.nokok.twitduke.components.actions;
+
+import javafx.event.EventHandler;
+import javafx.scene.control.TextArea;
+import javafx.scene.input.KeyEvent;
+
+/**
+ *
+ * @author wtnbsts
+ */
+public class MoveDown implements EventHandler<KeyEvent> {
+
+    @Override
+    public void handle(KeyEvent event) {
+        if ( !(event.getSource() instanceof TextArea) ) {
+            return;
+        }
+        final TextArea src = (TextArea) event.getSource();
+        final int downSidePosit = ActionUtil.getDownSide(src.getText(), src.getCaretPosition());
+        if ( downSidePosit < 0 ) {
+            return;
+        }
+        src.positionCaret(downSidePosit);
+    }
+}

--- a/TwitDuke-Components/src/main/java/net/nokok/twitduke/components/actions/MoveForward.java
+++ b/TwitDuke-Components/src/main/java/net/nokok/twitduke/components/actions/MoveForward.java
@@ -1,0 +1,24 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package net.nokok.twitduke.components.actions;
+
+import javafx.event.EventHandler;
+import javafx.scene.control.TextArea;
+import javafx.scene.input.KeyEvent;
+
+/**
+ *
+ * @author wtnbsts
+ */
+public class MoveForward implements EventHandler<KeyEvent> {
+
+    @Override
+    public void handle(KeyEvent event) {
+        if ( event.getSource() instanceof TextArea ) {
+            ((TextArea) event.getSource()).forward();
+        }
+    }
+}

--- a/TwitDuke-Components/src/main/java/net/nokok/twitduke/components/actions/MoveToBeginningOfLine.java
+++ b/TwitDuke-Components/src/main/java/net/nokok/twitduke/components/actions/MoveToBeginningOfLine.java
@@ -1,0 +1,26 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package net.nokok.twitduke.components.actions;
+
+import javafx.event.EventHandler;
+import javafx.scene.control.TextArea;
+import javafx.scene.input.KeyEvent;
+
+/**
+ *
+ * @author wtnbsts
+ */
+public class MoveToBeginningOfLine implements EventHandler<KeyEvent> {
+
+    @Override
+    public void handle(KeyEvent event) {
+        if ( !(event.getSource() instanceof TextArea) ) {
+            return;
+        }
+        final TextArea src = (TextArea) event.getSource();
+        src.positionCaret(ActionUtil.getBeginningOfLine(src.getText(), src.getCaretPosition()));
+    }
+}

--- a/TwitDuke-Components/src/main/java/net/nokok/twitduke/components/actions/MoveToEndOfLine.java
+++ b/TwitDuke-Components/src/main/java/net/nokok/twitduke/components/actions/MoveToEndOfLine.java
@@ -1,0 +1,26 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package net.nokok.twitduke.components.actions;
+
+import javafx.event.EventHandler;
+import javafx.scene.control.TextArea;
+import javafx.scene.input.KeyEvent;
+
+/**
+ *
+ * @author wtnbsts
+ */
+public class MoveToEndOfLine implements EventHandler<KeyEvent> {
+
+    @Override
+    public void handle(KeyEvent event) {
+        if ( !(event.getSource() instanceof TextArea) ) {
+            return;
+        }
+        final TextArea src = (TextArea) event.getSource();
+        src.positionCaret(ActionUtil.getEndOfLine(src.getText(), src.getCaretPosition()));
+    }
+}

--- a/TwitDuke-Components/src/main/java/net/nokok/twitduke/components/actions/MoveUp.java
+++ b/TwitDuke-Components/src/main/java/net/nokok/twitduke/components/actions/MoveUp.java
@@ -1,0 +1,30 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package net.nokok.twitduke.components.actions;
+
+import javafx.event.EventHandler;
+import javafx.scene.control.TextArea;
+import javafx.scene.input.KeyEvent;
+
+/**
+ *
+ * @author wtnbsts
+ */
+public class MoveUp implements EventHandler<KeyEvent> {
+
+    @Override
+    public void handle(KeyEvent event) {
+        if ( !(event.getSource() instanceof TextArea) ) {
+            return;
+        }
+        final TextArea src = (TextArea) event.getSource();
+        final int upSidePosit = ActionUtil.getUpSide(src.getText(), src.getCaretPosition());
+        if ( upSidePosit < 0 ) {
+            return;
+        }
+        src.positionCaret(upSidePosit);
+    }
+}

--- a/TwitDuke-Components/src/main/java/net/nokok/twitduke/components/actions/Paste.java
+++ b/TwitDuke-Components/src/main/java/net/nokok/twitduke/components/actions/Paste.java
@@ -1,0 +1,24 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package net.nokok.twitduke.components.actions;
+
+import javafx.event.EventHandler;
+import javafx.scene.control.TextArea;
+import javafx.scene.input.KeyEvent;
+
+/**
+ *
+ * @author wtnbsts
+ */
+public class Paste implements EventHandler<KeyEvent> {
+
+    @Override
+    public void handle(KeyEvent event) {
+        if ( event.getSource() instanceof TextArea ) {
+            ((TextArea) event.getSource()).paste();
+        }
+    }
+}

--- a/TwitDuke-Components/src/main/java/net/nokok/twitduke/components/keyevent/ActionRegister.java
+++ b/TwitDuke-Components/src/main/java/net/nokok/twitduke/components/keyevent/ActionRegister.java
@@ -1,0 +1,29 @@
+package net.nokok.twitduke.components.keyevent;
+
+import java.util.List;
+import javafx.scene.Node;
+
+/**
+ * Created by wtnbsts on 2014/07/26.
+ */
+public interface ActionRegister {
+
+    /**
+     * キーボードショートカットを設定するノードを指定して、キーボードショートカット設定インスタンスを生成する
+     *
+     * @param root キーボードを設定したいノード
+     *
+     * @return ショートカット設定インスタンス
+     */
+    static ActionRegister newInstance(final Node root) {
+        return new JavaFXActionRegister(root);
+    }
+
+    void registerKeyMap(final KeyMapSetting setting);
+
+    void unregisterAll();
+
+    List<Exception> getErrors();
+
+    void clearErrors();
+}

--- a/TwitDuke-Components/src/main/java/net/nokok/twitduke/components/keyevent/JavaFXActionRegister.java
+++ b/TwitDuke-Components/src/main/java/net/nokok/twitduke/components/keyevent/JavaFXActionRegister.java
@@ -1,0 +1,96 @@
+package net.nokok.twitduke.components.keyevent;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import javafx.event.EventHandler;
+import javafx.scene.Node;
+import javafx.scene.input.KeyEvent;
+
+/**
+ * Created by wtnbsts on 2014/07/29.
+ */
+public class JavaFXActionRegister implements ActionRegister {
+
+    private final Node root;
+    private final Map<Node, List<EventHandler<KeyEvent>>> registry = new HashMap<>();
+    private final List<Exception> errors = new ArrayList<>();
+
+    public JavaFXActionRegister(final Node root) {
+        this.root = root;
+    }
+
+    @Override
+    public void registerKeyMap(final KeyMapSetting setting) {
+        root.lookupAll("*")
+                .stream()
+                .filter(this::isResolvable)
+                .forEach(node -> {
+                    registerCall(node, setting);
+                });
+    }
+
+    @Override
+    public void unregisterAll() {
+        registry.forEach((node, handlerList) -> {
+            handlerList.forEach(handler -> {
+                try {
+                    node.removeEventHandler(KeyEvent.KEY_PRESSED, handler);
+                } catch (Exception ex) {
+                    errors.add(ex);
+                }
+            });
+        });
+    }
+
+    @Override
+    public List<Exception> getErrors() {
+        return errors.stream().collect(Collectors.toList());
+    }
+
+    @Override
+    public void clearErrors() {
+        errors.clear();;
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<EventHandler<KeyEvent>> registerCommand(final Node node, final Class<?> commandClass,
+                                                         final List<KeyBind> keyBinds) throws Exception {
+        List<EventHandler<KeyEvent>> added = new ArrayList<>();
+        EventHandler<KeyEvent> command = (EventHandler<KeyEvent>) commandClass.newInstance();
+        keyBinds.forEach(bind -> {
+            EventHandler<KeyEvent> adapter = event -> {
+                if ( bind.getKeyStroke().match(event) ) {
+                    command.handle(event);
+                }
+            };
+            node.addEventHandler(KeyEvent.KEY_PRESSED, adapter);
+            added.add(adapter);
+        });
+        return added;
+    }
+
+    private void registerCall(Node node, KeyMapSetting setting) {
+        String nodeClassName = node.getClass().getCanonicalName();
+        Map<String, List<KeyBind>> keyBindMap = setting.collectKeyBinds(nodeClassName).get();
+        if ( keyBindMap.isEmpty() ) {
+            return;
+        }
+        registry.putIfAbsent(node, new ArrayList<>());
+        keyBindMap.forEach((id, binds) -> {
+            try {
+                Class<?> commandClass = Class.forName(setting.getCommandClassName(id).get());
+                List<EventHandler<KeyEvent>> added = registerCommand(node, commandClass, binds);
+                registry.get(node).addAll(added);
+            } catch (Exception ex) {
+                errors.add(ex);
+            }
+        });
+    }
+
+    private boolean isResolvable(Object obj) {
+        return obj.getClass().getCanonicalName() != null;
+    }
+}


### PR DESCRIPTION
キーボードショートカットをjavafxのnodeに向けて登録＆解除するインターフェースActionRegisterと、その実装クラスを追加しました。
また、おまけで、各種ショートカットコマンドのクラスを追加しました。
以下、これまでに実装したクラス達の使い方例です。

```
Scene scene = new Scene(loader.load());
stage.setScene(scene);
stage.show();

KeyMapStore store = KeyMapStore.newInstance();
KeyMapSetting setting = store.load(KeyMapResources.DEFAULT_SETTING.get().openStream());
ActionRegister register = ActionRegister.newInstance(scene.getRoot());
register.registerKeyMap(setting);
```

以下、コミットログです。

```
キーバインド登録・解除の実装ができたっぽい？

ctrl+k 切り取り
ctrl+y 貼り付け
ctrl+a 行頭
ctrl+e 行末
etc...
```

邪悪なデフォルトメソッド周りは後でBuilderとかに書き直します。。。
