### PR TITLE
キーボードショートカットがまったく適用されないバグを修正

### DIFF
--- a/TwitDuke/src/main/java/net/nokok/twitduke/Main.java
+++ b/TwitDuke/src/main/java/net/nokok/twitduke/Main.java
@@ -80,10 +80,10 @@ public class Main extends Application {
             KeyMapStore store = new KeyMapStoreBuilder().build();
             KeyMapSetting setting = store.load(KeyMapResources.DEFAULT_SETTING.get().openStream());
             ActionRegister register = new ActionRegisterBuilder(main.getRoot()).build();
-            register.registerKeyMap(setting);
 
             stage.setScene(main);
             stage.show();
+            register.registerKeyMap(setting);
 
         } catch (IOException e) {
             throw new UncheckedIOException("FXMLファイルを読み込めませんでした。ファイルは見つかりましたが、ファイルがおかしいようです。", e);


### PR DESCRIPTION
showの後にregisterKeyMapを呼ばないと、キーボードショートカットが適用されません。

終了時のクラッシュ問題が気になりますが、
registerKeyMapの処理なら、showの後に呼んでも恐らくクラッシュしません。
